### PR TITLE
feat: add SQLite event logging and history CLI command

### DIFF
--- a/src/depeg_monitor/cli.py
+++ b/src/depeg_monitor/cli.py
@@ -1,11 +1,105 @@
-"""CLI entry point."""
+"""CLI entry point with history subcommand."""
 import asyncio
 import logging
 import sys
 import yaml
+from datetime import datetime
 from pathlib import Path
 from .config import MonitorConfig
 from .monitor import DepegMonitor
+from .storage import DepegDatabase
+
+
+def _load_config(config_path: str) -> MonitorConfig:
+    """Load configuration from YAML file."""
+    path = Path(config_path)
+    if path.exists():
+        with open(path) as f:
+            raw = yaml.safe_load(f)
+        return MonitorConfig(**raw) if raw else MonitorConfig()
+    logging.info(f"Config {config_path} not found, using defaults")
+    return MonitorConfig()
+
+
+def cmd_history(args: list[str]) -> None:
+    """Query and display historical depeg events."""
+    db_path = "depeg_events.db"
+    stablecoin = None
+    severity = None
+    hours = 24
+    limit = 50
+    show_stats = False
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("--db", "-d") and i + 1 < len(args):
+            db_path = args[i + 1]
+            i += 2
+        elif arg in ("--coin", "-c") and i + 1 < len(args):
+            stablecoin = args[i + 1].upper()
+            i += 2
+        elif arg in ("--severity", "-s") and i + 1 < len(args):
+            severity = args[i + 1].lower()
+            i += 2
+        elif arg in ("--hours", "-H") and i + 1 < len(args):
+            hours = int(args[i + 1])
+            i += 2
+        elif arg in ("--limit", "-l") and i + 1 < len(args):
+            limit = int(args[i + 1])
+            i += 2
+        elif arg == "--stats":
+            show_stats = True
+            i += 1
+        else:
+            i += 1
+
+    db = DepegDatabase(db_path)
+
+    if show_stats:
+        stats = db.get_stats(hours=hours)
+        print(f"\n📊 Depeg Monitor — Last {stats['period_hours']}h Summary")
+        print(f"{'=' * 50}")
+        print(f"  Total events:    {stats['total_events']}")
+        print(f"  Critical:        {stats['critical_events']}")
+        print(f"  Warnings:        {stats['warn_events']}")
+        print(f"  Coins affected:  {stats['coins_affected']}")
+        print(f"  Max deviation:   {stats['max_deviation']:.4%}")
+        print(f"  Avg deviation:   {stats['avg_deviation']:.4%}")
+        db.close()
+        return
+
+    events = db.query_history(
+        stablecoin=stablecoin,
+        severity=severity,
+        hours=hours,
+        limit=limit,
+    )
+
+    if not events:
+        print(f"No depeg events found in the last {hours}h.")
+        if stablecoin:
+            print(f"  (filtered by coin: {stablecoin})")
+        db.close()
+        return
+
+    header = f"📋 Depeg Events — Last {hours}h"
+    if stablecoin:
+        header += f" ({stablecoin})"
+    print(f"\n{header}")
+    print(f"{'=' * 80}")
+    print(f"{'Time':<21} {'Coin':<6} {'Source':<12} {'Price':<10} {'Deviation':<12} {'Severity'}")
+    print(f"{'-' * 80}")
+
+    for ev in events:
+        ts = datetime.fromtimestamp(ev.timestamp).strftime("%Y-%m-%d %H:%M:%S")
+        dev_str = f"{ev.deviation:.4%}"
+        sev = "🔴 CRITICAL" if ev.severity == "critical" else "🟡 WARN"
+        print(f"{ts:<21} {ev.stablecoin:<6} {ev.source:<12} {ev.price:<10.6f} {dev_str:<12} {sev}")
+
+    print(f"{'-' * 80}")
+    print(f"Showing {len(events)} events (limit: {limit})")
+    db.close()
 
 
 def main():
@@ -15,20 +109,17 @@ def main():
         datefmt="%H:%M:%S",
     )
 
+    # Subcommand routing
+    if len(sys.argv) > 1 and sys.argv[1] == "history":
+        cmd_history(sys.argv[2:])
+        return
+
     config_path = "config/default.yaml"
     for i, arg in enumerate(sys.argv):
         if arg == "--config" and i + 1 < len(sys.argv):
             config_path = sys.argv[i + 1]
 
-    path = Path(config_path)
-    if path.exists():
-        with open(path) as f:
-            raw = yaml.safe_load(f)
-        config = MonitorConfig(**raw) if raw else MonitorConfig()
-    else:
-        logging.info(f"Config {config_path} not found, using defaults")
-        config = MonitorConfig()
-
+    config = _load_config(config_path)
     monitor = DepegMonitor(config)
     asyncio.run(monitor.run())
 

--- a/src/depeg_monitor/config.py
+++ b/src/depeg_monitor/config.py
@@ -29,6 +29,8 @@ class AlertsConfig(BaseModel):
     # Telegram alert configuration
     telegram_bot_token: Optional[str] = None
     telegram_chat_id: Optional[str] = None
+    # SQLite event logging
+    db_path: Optional[str] = "depeg_events.db"
 
 
 class MonitorConfig(BaseModel):

--- a/src/depeg_monitor/database_alert.py
+++ b/src/depeg_monitor/database_alert.py
@@ -1,0 +1,31 @@
+"""Database alert — logs depeg events to SQLite for historical querying."""
+
+from .alerts.base import Alert, AlertLevel
+from .storage import DepegDatabase
+
+
+class DatabaseAlert(Alert):
+    """Persists every depeg event to SQLite storage.
+
+    This is not a traditional "alert" — it records events so they can be
+    queried later via ``depeg-monitor history``.
+    """
+
+    def __init__(self, db_path: str = "depeg_events.db"):
+        self.db = DepegDatabase(db_path)
+
+    async def send(
+        self, level: AlertLevel, symbol: str, price: float, peg: float, source: str
+    ) -> None:
+        deviation = abs(price - peg) / peg
+        self.db.log_event(
+            stablecoin=symbol,
+            source=source,
+            price=price,
+            peg=peg,
+            deviation=deviation,
+            level=level,
+        )
+
+    def close(self) -> None:
+        self.db.close()

--- a/src/depeg_monitor/monitor.py
+++ b/src/depeg_monitor/monitor.py
@@ -12,6 +12,7 @@ from .alerts.base import Alert, AlertLevel
 from .alerts.console import ConsoleAlert
 from .alerts.webhook import WebhookAlert
 from .alerts.telegram import TelegramAlert
+from .database_alert import DatabaseAlert
 
 logger = logging.getLogger("depeg-monitor")
 
@@ -48,6 +49,9 @@ class DepegMonitor:
                     self.config.alerts.telegram_chat_id,
                 )
             )
+        # SQLite event logging
+        if self.config.alerts.db_path:
+            alerts.append(DatabaseAlert(self.config.alerts.db_path))
         return alerts
 
     async def check_once(self) -> None:

--- a/src/depeg_monitor/storage.py
+++ b/src/depeg_monitor/storage.py
@@ -1,0 +1,187 @@
+"""SQLite storage for historical depeg event logging."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from .alerts.base import AlertLevel
+
+
+class Severity(Enum):
+    """Stored severity levels (maps from AlertLevel)."""
+    WARN = "warn"
+    CRITICAL = "critical"
+
+
+@dataclass
+class DepegEvent:
+    """A single recorded depeg event."""
+    id: Optional[int] = None
+    timestamp: float = 0.0
+    stablecoin: str = ""
+    source: str = ""
+    price: float = 0.0
+    peg: float = 1.0
+    deviation: float = 0.0
+    severity: str = "warn"
+
+
+class DepegDatabase:
+    """SQLite-backed storage for depeg events."""
+
+    def __init__(self, db_path: str = "depeg_events.db"):
+        self.db_path = db_path
+        self._conn: Optional[sqlite3.Connection] = None
+        self._init_db()
+
+    def _init_db(self) -> None:
+        """Create the events table if it doesn't exist."""
+        self.conn.execute("""
+            CREATE TABLE IF NOT EXISTS depeg_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp REAL NOT NULL,
+                stablecoin TEXT NOT NULL,
+                source TEXT NOT NULL,
+                price REAL NOT NULL,
+                peg REAL NOT NULL,
+                deviation REAL NOT NULL,
+                severity TEXT NOT NULL
+            )
+        """)
+        self.conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_depeg_stablecoin
+            ON depeg_events(stablecoin)
+        """)
+        self.conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_depeg_timestamp
+            ON depeg_events(timestamp DESC)
+        """)
+        self.conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_depeg_severity
+            ON depeg_events(severity)
+        """)
+        self.conn.commit()
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        """Lazy connection — opens on first access."""
+        if self._conn is None:
+            Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(self.db_path)
+            self._conn.row_factory = sqlite3.Row
+        return self._conn
+
+    def log_event(
+        self,
+        stablecoin: str,
+        source: str,
+        price: float,
+        peg: float,
+        deviation: float,
+        level: AlertLevel,
+    ) -> DepegEvent:
+        """Insert a new depeg event and return it."""
+        now = time.time()
+        severity = level.value
+        cur = self.conn.execute(
+            """INSERT INTO depeg_events
+               (timestamp, stablecoin, source, price, peg, deviation, severity)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (now, stablecoin, source, price, peg, deviation, severity),
+        )
+        self.conn.commit()
+        return DepegEvent(
+            id=cur.lastrowid,
+            timestamp=now,
+            stablecoin=stablecoin,
+            source=source,
+            price=price,
+            peg=peg,
+            deviation=deviation,
+            severity=severity,
+        )
+
+    def query_history(
+        self,
+        stablecoin: Optional[str] = None,
+        severity: Optional[str] = None,
+        hours: int = 24,
+        limit: int = 50,
+    ) -> list[DepegEvent]:
+        """Query historical depeg events.
+
+        Args:
+            stablecoin: Filter by symbol (e.g. "USDC"). None = all.
+            severity: Filter by severity ("warn" or "critical"). None = all.
+            hours: Look back this many hours.
+            limit: Max rows to return.
+        """
+        since = time.time() - hours * 3600
+        clauses = ["timestamp >= ?"]
+        params: list = [since]
+
+        if stablecoin:
+            clauses.append("stablecoin = ?")
+            params.append(stablecoin)
+        if severity:
+            clauses.append("severity = ?")
+            params.append(severity)
+
+        where = " AND ".join(clauses)
+        params.append(limit)
+
+        rows = self.conn.execute(
+            f"SELECT * FROM depeg_events WHERE {where} ORDER BY timestamp DESC LIMIT ?",
+            params,
+        ).fetchall()
+
+        return [
+            DepegEvent(
+                id=r["id"],
+                timestamp=r["timestamp"],
+                stablecoin=r["stablecoin"],
+                source=r["source"],
+                price=r["price"],
+                peg=r["peg"],
+                deviation=r["deviation"],
+                severity=r["severity"],
+            )
+            for r in rows
+        ]
+
+    def get_stats(self, hours: int = 24) -> dict:
+        """Get summary statistics for the time window."""
+        since = time.time() - hours * 3600
+        row = self.conn.execute(
+            """SELECT
+                   COUNT(*) as total_events,
+                   COUNT(CASE WHEN severity = 'critical' THEN 1 END) as critical_count,
+                   COUNT(CASE WHEN severity = 'warn' THEN 1 END) as warn_count,
+                   COUNT(DISTINCT stablecoin) as coins_affected,
+                   MAX(deviation) as max_deviation,
+                   AVG(deviation) as avg_deviation
+               FROM depeg_events
+               WHERE timestamp >= ?""",
+            (since,),
+        ).fetchone()
+        return {
+            "period_hours": hours,
+            "total_events": row["total_events"],
+            "critical_events": row["critical_count"],
+            "warn_events": row["warn_count"],
+            "coins_affected": row["coins_affected"],
+            "max_deviation": round(row["max_deviation"], 6) if row["max_deviation"] else 0,
+            "avg_deviation": round(row["avg_deviation"], 6) if row["avg_deviation"] else 0,
+        }
+
+    def close(self) -> None:
+        """Close the database connection."""
+        if self._conn:
+            self._conn.close()
+            self._conn = None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,167 @@
+"""Tests for SQLite depeg event storage."""
+
+import os
+import tempfile
+import time
+import pytest
+
+from depeg_monitor.storage import DepegDatabase, DepegEvent
+from depeg_monitor.alerts.base import AlertLevel
+from depeg_monitor.database_alert import DatabaseAlert
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Create a temporary database."""
+    path = str(tmp_path / "test.db")
+    database = DepegDatabase(path)
+    yield database
+    database.close()
+
+
+class TestDepegDatabase:
+    def test_creates_tables(self, db):
+        """Database should create tables on init."""
+        tables = db.conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        names = [t["name"] for t in tables]
+        assert "depeg_events" in names
+
+    def test_log_and_retrieve_event(self, db):
+        """Logging an event and querying it should work."""
+        event = db.log_event(
+            stablecoin="USDC",
+            source="binance",
+            price=0.985,
+            peg=1.0,
+            deviation=0.015,
+            level=AlertLevel.CRITICAL,
+        )
+        assert event.id is not None
+        assert event.stablecoin == "USDC"
+        assert event.severity == "critical"
+
+        events = db.query_history()
+        assert len(events) == 1
+        assert events[0].stablecoin == "USDC"
+
+    def test_query_filters_by_stablecoin(self, db):
+        """Query should filter by stablecoin."""
+        db.log_event("USDC", "binance", 0.985, 1.0, 0.015, AlertLevel.WARN)
+        db.log_event("USDT", "coinbase", 0.97, 1.0, 0.03, AlertLevel.CRITICAL)
+
+        usdc = db.query_history(stablecoin="USDC")
+        assert len(usdc) == 1
+        assert usdc[0].stablecoin == "USDC"
+
+        usdt = db.query_history(stablecoin="USDT")
+        assert len(usdt) == 1
+
+        all_events = db.query_history()
+        assert len(all_events) == 2
+
+    def test_query_filters_by_severity(self, db):
+        """Query should filter by severity."""
+        db.log_event("USDC", "binance", 0.985, 1.0, 0.015, AlertLevel.WARN)
+        db.log_event("USDC", "coinbase", 0.97, 1.0, 0.03, AlertLevel.CRITICAL)
+
+        critical = db.query_history(severity="critical")
+        assert len(critical) == 1
+        assert critical[0].severity == "critical"
+
+        warn = db.query_history(severity="warn")
+        assert len(warn) == 1
+
+    def test_query_respects_limit(self, db):
+        """Query should respect the limit parameter."""
+        for i in range(10):
+            db.log_event("USDC", "binance", 0.99 - i * 0.001, 1.0, 0.01 + i * 0.001, AlertLevel.WARN)
+
+        events = db.query_history(limit=3)
+        assert len(events) == 3
+
+    def test_query_most_recent_first(self, db):
+        """Events should be returned newest first."""
+        db.log_event("USDC", "binance", 0.99, 1.0, 0.01, AlertLevel.WARN)
+        time.sleep(0.01)
+        db.log_event("USDT", "coinbase", 0.97, 1.0, 0.03, AlertLevel.CRITICAL)
+
+        events = db.query_history()
+        assert events[0].stablecoin == "USDT"  # more recent
+        assert events[1].stablecoin == "USDC"
+
+    def test_get_stats(self, db):
+        """Stats should aggregate correctly."""
+        db.log_event("USDC", "binance", 0.985, 1.0, 0.015, AlertLevel.WARN)
+        db.log_event("USDT", "coinbase", 0.97, 1.0, 0.03, AlertLevel.CRITICAL)
+        db.log_event("DAI", "binance", 0.96, 1.0, 0.04, AlertLevel.CRITICAL)
+
+        stats = db.get_stats(hours=1)
+        assert stats["total_events"] == 3
+        assert stats["critical_events"] == 2
+        assert stats["warn_events"] == 1
+        assert stats["coins_affected"] == 3
+        assert stats["max_deviation"] == 0.04
+        assert stats["avg_deviation"] == pytest.approx(0.028333, abs=1e-4)
+
+    def test_get_stats_empty(self, db):
+        """Stats should return zeros when no events."""
+        stats = db.get_stats(hours=1)
+        assert stats["total_events"] == 0
+        assert stats["critical_events"] == 0
+
+    def test_close_and_reopen(self, tmp_path):
+        """Database should persist across close/reopen."""
+        path = str(tmp_path / "persist.db")
+        db1 = DepegDatabase(path)
+        db1.log_event("USDC", "binance", 0.99, 1.0, 0.01, AlertLevel.WARN)
+        db1.close()
+
+        db2 = DepegDatabase(path)
+        events = db2.query_history()
+        assert len(events) == 1
+        assert events[0].stablecoin == "USDC"
+        db2.close()
+
+    def test_db_path_creates_parent_dirs(self, tmp_path):
+        """Should create parent directories if they don't exist."""
+        path = str(tmp_path / "nested" / "dir" / "test.db")
+        db = DepegDatabase(path)
+        db.log_event("USDC", "binance", 0.99, 1.0, 0.01, AlertLevel.WARN)
+        events = db.query_history()
+        assert len(events) == 1
+        db.close()
+
+
+class TestDatabaseAlert:
+    @pytest.mark.asyncio
+    async def test_send_logs_event(self, tmp_path):
+        """DatabaseAlert.send() should persist an event."""
+        path = str(tmp_path / "alert.db")
+        alert = DatabaseAlert(path)
+
+        await alert.send(AlertLevel.CRITICAL, "USDC", 0.985, 1.0, "binance")
+
+        db = DepegDatabase(path)
+        events = db.query_history()
+        assert len(events) == 1
+        assert events[0].stablecoin == "USDC"
+        assert events[0].severity == "critical"
+        assert events[0].deviation == pytest.approx(0.015)
+        db.close()
+        alert.close()
+
+    @pytest.mark.asyncio
+    async def test_send_computes_deviation(self, tmp_path):
+        """DatabaseAlert should compute deviation from price and peg."""
+        path = str(tmp_path / "dev.db")
+        alert = DatabaseAlert(path)
+
+        await alert.send(AlertLevel.WARN, "DAI", 0.992, 1.0, "uniswap")
+
+        db = DepegDatabase(path)
+        events = db.query_history()
+        assert events[0].deviation == pytest.approx(0.008)
+        db.close()
+        alert.close()


### PR DESCRIPTION
Closes #3

## What
Adds historical depeg event logging to SQLite with a `depeg-monitor history` CLI command.

## Changes
- **`src/depeg_monitor/storage.py`** — `DepegDatabase` class with:
  - Auto-creates tables and indexes (timestamp, stablecoin, severity)
  - `log_event()`: insert depeg events with timestamp, coin, source, price, deviation, severity
  - `query_history()`: filter by coin, severity, time window; newest-first with configurable limit
  - `get_stats()`: aggregate stats (total/critical/warn events, max/avg deviation)
  - Lazy connection, auto-creates parent directories

- **`src/depeg_monitor/database_alert.py`** — `DatabaseAlert` that plugs into the existing alert pipeline
  - Computes deviation from price/peg automatically
  - Records every depeg event to SQLite

- **`src/depeg_monitor/cli.py`** — New `history` subcommand:
  - `depeg-monitor history` — show last 24h events
  - `depeg-monitor history --coin USDC --severity critical --hours 48 --limit 20`
  - `depeg-monitor history --stats` — summary statistics

- **`src/depeg_monitor/config.py`** — Added `alerts.db_path` field (default: `depeg_events.db`)

## Tests
12 new tests covering:
- Table creation and persistence
- Event logging and retrieval
- Filtering by stablecoin and severity
- Limit enforcement and ordering
- Stats aggregation (empty and non-empty)
- Close/reopen persistence
- DatabaseAlert async send
- Auto-creation of parent directories

All 22 tests passing.