### PR TITLE
docs: fix incorrect "bps semantics" description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ depeg-monitor --config config/default.yaml
 A zero-build static dashboard lives in [`web/`](web/). Run it locally with
 `python3 -m http.server -d web 8080` — it polls Binance, Coinbase, and
 CoinGecko every 30s and renders median-aggregated peg status with
-adjustable warn / critical thresholds (same bps semantics as this library's
+adjustable warn / critical thresholds (same threshold semantics as this library's
 `config/default.yaml`). See [`web/README.md`](web/README.md) for details.
 
 ## Features


### PR DESCRIPTION
### What
Replace the inaccurate term "bps semantics" with "threshold semantics" in the README's dashboard description.

### Why
The `config/default.yaml` thresholds are expressed as decimal fractions (`warn_threshold: 0.005` = 0.5%), **not** in basis points (which would be `50`). Calling them "bps semantics" is misleading to users who expect bps values like 50 or 100.

Small, scoped fix from kcolbchain contrib-bot.