### PR TITLE
chore: cleanup pass — install ergonomics, dead code, log hardening

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,7 @@ Thank you to everyone who has contributed to depeg-monitor.
 
 | Contributor | Contributions |
 |-------------|---------------|
-| [@alexanderxfgl-bit](https://github.com/alexanderxfgl-bit) | Integration tests with mock price feeds (#7) |
+| [@alexanderxfgl-bit](https://github.com/alexanderxfgl-bit) | Integration tests with mock price feeds (#7); Telegram alert channel (#10); SQLite event logging and history CLI (#11); Curve pool price source (#12) |
 
 ## Maintainers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,11 @@ name = "depeg-monitor"
 version = "0.1.0"
 dependencies = ["aiohttp>=3.9.0", "web3>=6.0.0", "pydantic>=2.0.0", "pyyaml>=6.0.0"]
 
+[project.scripts]
+depeg-monitor = "depeg_monitor.cli:main"
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/depeg_monitor/alerts/telegram.py
+++ b/src/depeg_monitor/alerts/telegram.py
@@ -10,13 +10,16 @@ Configure via config:
 from __future__ import annotations
 
 import logging
-from urllib.parse import quote
 
 import aiohttp
 
 from .base import Alert, AlertLevel
 
 logger = logging.getLogger("depeg-monitor")
+
+
+def _redact(message: str, token: str) -> str:
+    return message.replace(token, "<redacted>") if token else message
 
 
 class TelegramAlert(Alert):
@@ -99,11 +102,6 @@ class TelegramAlert(Alert):
             "disable_web_page_preview": True,
         }
 
-        # For critical alerts, also disable notification sound if supported
-        if level == AlertLevel.CRITICAL:
-            # Critical alerts should be noisy - don't disable_notification
-            pass
-
         session = await self._get_session()
 
         try:
@@ -119,16 +117,16 @@ class TelegramAlert(Alert):
                 elif resp.status == 403:
                     logger.error("Telegram: Bot not in chat or chat_id invalid")
                 elif resp.status == 429:
-                    # Rate limited - back off
                     retry_after = resp.headers.get("Retry-After", "30")
                     logger.warning(f"Telegram rate limited, retry after {retry_after}s")
                 else:
                     logger.warning(f"Telegram returned {resp.status}")
 
         except aiohttp.ClientError as e:
-            logger.warning(f"Telegram connection error: {e}")
+            # Redact bot token from any URL embedded in the error message.
+            logger.warning(f"Telegram connection error: {_redact(str(e), self._token)}")
         except Exception as e:
-            logger.error(f"Telegram unexpected error: {e}")
+            logger.error(f"Telegram unexpected error: {_redact(str(e), self._token)}")
 
     async def close(self) -> None:
         """Close the HTTP session."""

--- a/src/depeg_monitor/config.py
+++ b/src/depeg_monitor/config.py
@@ -29,8 +29,8 @@ class AlertsConfig(BaseModel):
     # Telegram alert configuration
     telegram_bot_token: Optional[str] = None
     telegram_chat_id: Optional[str] = None
-    # SQLite event logging
-    db_path: Optional[str] = "depeg_events.db"
+    # SQLite event logging — opt-in; set a path to enable
+    db_path: Optional[str] = None
 
 
 class MonitorConfig(BaseModel):

--- a/src/depeg_monitor/sources/curve.py
+++ b/src/depeg_monitor/sources/curve.py
@@ -1,6 +1,9 @@
 """Curve stableswap pool price source — reads virtual price from Curve pools."""
 
+from typing import Any
+
 from web3 import Web3
+
 from .base import PriceSource
 
 # Major Curve stableswap pools on Ethereum mainnet
@@ -88,7 +91,7 @@ class CurvePoolSource(PriceSource):
 
     def __init__(self, rpc_url: str):
         self.w3 = Web3(Web3.HTTPProvider(rpc_url))
-        self._contracts: dict[str, any] = {}
+        self._contracts: dict[str, Any] = {}
 
     def _get_pool_contract(self, pool_addr: str):
         """Get or create a cached pool contract instance."""

--- a/src/depeg_monitor/storage.py
+++ b/src/depeg_monitor/storage.py
@@ -5,18 +5,10 @@ from __future__ import annotations
 import sqlite3
 import time
 from dataclasses import dataclass
-from datetime import datetime, timedelta
-from enum import Enum
 from pathlib import Path
 from typing import Optional
 
 from .alerts.base import AlertLevel
-
-
-class Severity(Enum):
-    """Stored severity levels (maps from AlertLevel)."""
-    WARN = "warn"
-    CRITICAL = "critical"
 
 
 @dataclass

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,16 +15,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from src.depeg_monitor.monitor import DepegMonitor
-from src.depeg_monitor.config import (
+from depeg_monitor.monitor import DepegMonitor
+from depeg_monitor.config import (
     MonitorConfig,
     StablecoinConfig,
     SourcesConfig,
     DexSourceConfig,
     AlertsConfig,
 )
-from src.depeg_monitor.sources.base import PriceSource
-from src.depeg_monitor.alerts.base import Alert, AlertLevel
+from depeg_monitor.sources.base import PriceSource
+from depeg_monitor.alerts.base import Alert, AlertLevel
 
 
 # --- Mock Price Sources ---
@@ -149,8 +149,8 @@ async def test_normal_ops_slight_deviation(monitor_with_mocks, mock_alert):
 
 
 @pytest.mark.asyncio
-async def test_warn_level_depeg_above(monitor_with_mocks, mock_alert):
-    """Price at 0.7% deviation should trigger a WARN alert."""
+async def test_warn_level_below_peg(monitor_with_mocks, mock_alert):
+    """Price at 0.7% below peg should trigger a WARN alert."""
     monitor = monitor_with_mocks
     # 0.993 = 0.7% below peg, above 0.5% warn threshold
     monitor.sources = [MockPriceSource("mock-cex", {"USDC": 0.993})]
@@ -165,7 +165,7 @@ async def test_warn_level_depeg_above(monitor_with_mocks, mock_alert):
 
 
 @pytest.mark.asyncio
-async def test_warn_level_depeg_below_peg(monitor_with_mocks, mock_alert):
+async def test_warn_level_above_peg(monitor_with_mocks, mock_alert):
     """Price above peg at warn level should also trigger WARN."""
     monitor = monitor_with_mocks
     monitor.sources = [MockPriceSource("mock-cex", {"USDC": 1.007})]


### PR DESCRIPTION
## Summary

Low-risk cleanup pass with no behavioral changes to the monitor loop, sources, or alert dispatch. All 47 tests pass.

- **pyproject** — declare `[project.scripts]` so `pip install -e .` actually installs the `depeg-monitor` CLI command (the README has been claiming it for a while, but the entry point was missing — verified locally that the command now appears in the venv `bin/`). Also declare `pytest` + `pytest-asyncio` as `dev` extras.
- **config** — `AlertsConfig.db_path` default `"depeg_events.db"` → `None`. Brings SQLite logging in line with the other channels (opt-in) and stops a stray `depeg_events.db` from being written into the cwd of anyone who builds a `DepegMonitor` with default config (notably, the integration tests, which were silently dropping the file on every run).
- **telegram** — drop unused `urllib.parse.quote` import and the no-op `if level == AlertLevel.CRITICAL: pass` block. Redact the bot token from connection-error log lines (the API URL embeds the token; `aiohttp` errors often carry the URL).
- **storage** — remove unused `Severity` enum and dead `datetime`/`timedelta` imports — the code stores `AlertLevel.value` directly.
- **curve** — `dict[str, any]` → `dict[str, Any]` (lowercase `any` is the built-in function, not the type; mypy flags it).
- **tests/integration** — switch `from src.depeg_monitor.*` → `from depeg_monitor.*` to match the other test modules and the installed package layout. Rename `test_warn_level_depeg_above` / `test_warn_level_depeg_below_peg` → `test_warn_level_below_peg` / `test_warn_level_above_peg` so the names match the price data they assert on.
- **CONTRIBUTORS** — credit @alexanderxfgl-bit for #10, #11, #12 in addition to #7.

## Follow-ups deliberately not in this PR

Filing/noting separately so this one stays reviewable:
- Curve `get_dy` includes the 0.04% swap fee, so a perfectly balanced 3pool returns ~0.9996, not 1.0 — only relevant if anyone tightens `warn_threshold` below ~5bps.
- `UniswapV3Source` and `CurvePoolSource` use synchronous `.call()` inside `async def get_price`, which blocks the event loop.
- `TelegramAlert` caches its `aiohttp.ClientSession` and `monitor.py` never closes it; an "Unclosed client session" warning fires at shutdown.
- `cli.py history` is a hand-rolled argv parser; `--hours foo` crashes uncaught. Worth porting to `argparse`.
- Storage `get_stats` has no `stablecoin` filter even though `query_history` does.
- Issue #9 (systemd + `/health` endpoint) was auto-closed by `pipeline: stale` on 2026-05-12. Now that the CLI entry point is wired, the systemd unit can shell out to `depeg-monitor`.

## Test plan

- [x] `pytest tests/ -q` — 47 passed locally in a fresh venv with `pip install -e .[dev]`
- [x] `depeg-monitor` command appears in `$VENV/bin/` and starts the monitor loop
- [x] `py_compile` clean across all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)