### PR TITLE
fix: drop delisted Binance DAI pair + add price>0 guard + coverage log

### DIFF
--- a/src/depeg_monitor/monitor.py
+++ b/src/depeg_monitor/monitor.py
@@ -76,10 +76,26 @@ class DepegMonitor:
             for alert in self.alerts:
                 await alert.send(level, coin.symbol, price, coin.peg, source.name)
 
+    def _log_coverage(self) -> None:
+        """Log which (source × stablecoin) pairs will actually be exercised.
+
+        Each source's ``supports(symbol)`` decides whether that pair shows up;
+        a source with no overlap is still in the list but will be a no-op for
+        the configured symbols. Surfacing this on startup catches misconfigs
+        like a delisted exchange pair without waiting for the first cycle.
+        """
+        symbols = [c.symbol for c in self.config.stablecoins]
+        for source in self.sources:
+            covered = [s for s in symbols if source.supports(s)]
+            label = ", ".join(covered) if covered else "(none)"
+            logger.info(f"  {source.name:<11} → {label}")
+
     async def run(self) -> None:
         logger.info(f"Starting depeg-monitor — checking every {self.config.interval_seconds}s")
         logger.info(f"Watching: {', '.join(c.symbol for c in self.config.stablecoins)}")
         logger.info(f"Sources: {', '.join(s.name for s in self.sources)}")
+        logger.info("Source coverage:")
+        self._log_coverage()
 
         while True:
             try:

--- a/src/depeg_monitor/sources/base.py
+++ b/src/depeg_monitor/sources/base.py
@@ -14,3 +14,12 @@ class PriceSource(ABC):
     @abstractmethod
     def name(self) -> str:
         ...
+
+    def supports(self, symbol: str) -> bool:
+        """Whether this source can theoretically price ``symbol``.
+
+        Default returns True; concrete sources should override based on their
+        symbol mapping so the monitor can log a real coverage matrix at startup
+        instead of silently no-op'ing on unsupported pairs.
+        """
+        return True

--- a/src/depeg_monitor/sources/cex.py
+++ b/src/depeg_monitor/sources/cex.py
@@ -2,13 +2,18 @@
 import aiohttp
 from .base import PriceSource
 
-# Symbol mapping: our symbol → exchange trading pair
-BINANCE_PAIRS = {"USDT": "USDCUSDT", "USDC": "USDCUSDT", "DAI": "DAIUSDT"}
+# Symbol mapping: our symbol → exchange trading pair.
+# Binance has no live DAI pair (DAIUSDT was delisted; the endpoint still
+# returns 200 with price="0.00000000"), so DAI is intentionally absent here.
+BINANCE_PAIRS = {"USDT": "USDCUSDT", "USDC": "USDCUSDT"}
 COINBASE_PAIRS = {"USDT": "USDT-USD", "USDC": "USDC-USD", "DAI": "DAI-USD"}
 
 
 class BinanceSource(PriceSource):
     name = "binance"
+
+    def supports(self, symbol: str) -> bool:
+        return symbol.upper() in BINANCE_PAIRS
 
     async def get_price(self, symbol: str) -> float | None:
         pair = BINANCE_PAIRS.get(symbol.upper())
@@ -22,9 +27,14 @@ class BinanceSource(PriceSource):
                         return None
                     data = await resp.json()
                     price = float(data["price"])
+                    # Binance returns HTTP 200 with price="0.00000000" for
+                    # delisted-but-still-queryable pairs. Treat non-positive
+                    # prices as unavailable to avoid phantom 100% depegs.
+                    if price <= 0:
+                        return None
                     # USDCUSDT returns USDC/USDT — for USDT we invert
                     if symbol.upper() == "USDT" and pair == "USDCUSDT":
-                        return 1.0 / price if price > 0 else None
+                        return 1.0 / price
                     return price
         except Exception:
             return None
@@ -32,6 +42,9 @@ class BinanceSource(PriceSource):
 
 class CoinbaseSource(PriceSource):
     name = "coinbase"
+
+    def supports(self, symbol: str) -> bool:
+        return symbol.upper() in COINBASE_PAIRS
 
     async def get_price(self, symbol: str) -> float | None:
         pair = COINBASE_PAIRS.get(symbol.upper())
@@ -44,6 +57,9 @@ class CoinbaseSource(PriceSource):
                     if resp.status != 200:
                         return None
                     data = await resp.json()
-                    return float(data["data"]["amount"])
+                    price = float(data["data"]["amount"])
+                    if price <= 0:
+                        return None
+                    return price
         except Exception:
             return None

--- a/src/depeg_monitor/sources/curve.py
+++ b/src/depeg_monitor/sources/curve.py
@@ -90,6 +90,9 @@ class CurvePoolSource(PriceSource):
         self.w3 = Web3(Web3.HTTPProvider(rpc_url))
         self._contracts: dict[str, any] = {}
 
+    def supports(self, symbol: str) -> bool:
+        return symbol.upper() in CURVE_POOLS
+
     def _get_pool_contract(self, pool_addr: str):
         """Get or create a cached pool contract instance."""
         if pool_addr not in self._contracts:

--- a/src/depeg_monitor/sources/dex.py
+++ b/src/depeg_monitor/sources/dex.py
@@ -35,6 +35,9 @@ class UniswapV3Source(PriceSource):
     def __init__(self, rpc_url: str):
         self.w3 = Web3(Web3.HTTPProvider(rpc_url))
 
+    def supports(self, symbol: str) -> bool:
+        return symbol.upper() in POOLS
+
     async def get_price(self, symbol: str) -> float | None:
         pool_addr = POOLS.get(symbol.upper())
         if not pool_addr:

--- a/tests/test_cex_source.py
+++ b/tests/test_cex_source.py
@@ -1,0 +1,90 @@
+"""Tests for the CEX price sources."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from depeg_monitor.sources.cex import (
+    BINANCE_PAIRS,
+    COINBASE_PAIRS,
+    BinanceSource,
+    CoinbaseSource,
+)
+
+
+def _mock_aiohttp_session(json_payload: dict, status: int = 200):
+    """Build a MagicMock that behaves like an aiohttp.ClientSession."""
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=json_payload)
+    response.__aenter__ = AsyncMock(return_value=response)
+    response.__aexit__ = AsyncMock(return_value=False)
+
+    session = MagicMock()
+    session.get = MagicMock(return_value=response)
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    return session
+
+
+class TestBinanceSource:
+    def test_supports_only_mapped_symbols(self):
+        src = BinanceSource()
+        assert src.supports("USDC")
+        assert src.supports("USDT")
+        # Binance has no live DAI pair — must report False so monitor coverage
+        # log makes that explicit instead of silently no-op'ing each cycle.
+        assert not src.supports("DAI")
+
+    def test_dai_not_in_binance_map(self):
+        """Regression guard for the delisted DAIUSDT pair."""
+        assert "DAI" not in BINANCE_PAIRS
+
+    @pytest.mark.asyncio
+    async def test_zero_price_returns_none(self):
+        """Delisted pairs return HTTP 200 with price='0.00000000' — not a depeg."""
+        session = _mock_aiohttp_session({"symbol": "USDCUSDT", "price": "0.00000000"})
+        with patch("depeg_monitor.sources.cex.aiohttp.ClientSession", return_value=session):
+            price = await BinanceSource().get_price("USDC")
+        assert price is None
+
+    @pytest.mark.asyncio
+    async def test_negative_price_returns_none(self):
+        session = _mock_aiohttp_session({"symbol": "USDCUSDT", "price": "-1.0"})
+        with patch("depeg_monitor.sources.cex.aiohttp.ClientSession", return_value=session):
+            price = await BinanceSource().get_price("USDC")
+        assert price is None
+
+    @pytest.mark.asyncio
+    async def test_valid_price_passes_through(self):
+        session = _mock_aiohttp_session({"symbol": "USDCUSDT", "price": "1.00093"})
+        with patch("depeg_monitor.sources.cex.aiohttp.ClientSession", return_value=session):
+            price = await BinanceSource().get_price("USDC")
+        assert price == pytest.approx(1.00093)
+
+    @pytest.mark.asyncio
+    async def test_usdt_inversion(self):
+        """USDT is priced as 1 / USDCUSDT — but only when USDCUSDT > 0."""
+        session = _mock_aiohttp_session({"symbol": "USDCUSDT", "price": "1.00093"})
+        with patch("depeg_monitor.sources.cex.aiohttp.ClientSession", return_value=session):
+            price = await BinanceSource().get_price("USDT")
+        assert price == pytest.approx(1.0 / 1.00093)
+
+
+class TestCoinbaseSource:
+    def test_supports_dai(self):
+        # Coinbase still lists DAI-USD — this is the fallback that keeps DAI
+        # covered after Binance was dropped.
+        assert CoinbaseSource().supports("DAI")
+
+    def test_unsupported_symbol(self):
+        assert not CoinbaseSource().supports("BTC")
+
+    @pytest.mark.asyncio
+    async def test_zero_price_returns_none(self):
+        session = _mock_aiohttp_session(
+            {"data": {"amount": "0", "base": "DAI", "currency": "USD"}}
+        )
+        with patch("depeg_monitor.sources.cex.aiohttp.ClientSession", return_value=session):
+            price = await CoinbaseSource().get_price("DAI")
+        assert price is None


### PR DESCRIPTION
## Summary

Fixes the live monitor firing CRITICAL alerts for DAI on every cycle.

**Root cause:** The DAIUSDT pair is delisted from Binance, but the v3 ticker endpoint still returns `HTTP 200 { "price": "0.00000000" }`. `BinanceSource` took that at face value, the monitor read it as a 100% depeg, and `ConsoleAlert` fired CRITICAL forever.

Verified live:

```
$ curl https://api.binance.com/api/v3/ticker/price?symbol=DAIUSDT
{"symbol":"DAIUSDT","price":"0.00000000"}    (HTTP 200)
```

`exchangeInfo` confirms no active DAI pair on Binance today (the only `DAI` match is `ADAIDR` = ADA/IDR). Coinbase still prices DAI-USD at ~$0.9995, so DAI coverage is preserved via Coinbase + Uniswap V3 + Curve.

## Changes

- **`sources/cex.py`** — drop `"DAI": "DAIUSDT"` from `BINANCE_PAIRS`. Add a `price <= 0` guard to both `BinanceSource` and `CoinbaseSource` so future delistings or anomalous responses can't reproduce the same phantom-depeg pattern.
- **`sources/base.py`** — add a concrete `supports(symbol) -> bool` method (default `True`; subclasses override). Existing `get_price` semantics unchanged.
- **`sources/{cex,dex,curve}.py`** — implement `supports()` from each source's existing symbol map.
- **`monitor.py`** — log a per-source coverage table at startup so operators see which (source × stablecoin) pairs will actually be exercised. Example with the default config:

  ```
  Starting depeg-monitor — checking every 30s
  Watching: USDC, USDT, DAI
  Sources: binance, coinbase, uniswap_v3, curve
  Source coverage:
    binance     → USDC, USDT
    coinbase    → USDC, USDT, DAI
    uniswap_v3  → USDC, USDT, DAI
    curve       → USDC, USDT, DAI
  ```

- **`tests/test_cex_source.py`** — new file. Regression tests for the zero-price guard (Binance + Coinbase), the absence of DAI from `BINANCE_PAIRS`, and `supports()` on both CEX sources.

## Relationship to #14

Independent. PR #14 is non-behavioral cleanup; this one is the behavioral fix you noticed in that PR's review thread. They touch disjoint files (#14 doesn't touch `sources/cex.py`; this one doesn't touch the files #14 changed) and merge cleanly in either order.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_integration.py -q` — 43 passed (integration tests are broken on `main` by a separate import issue that #14 fixes; once both land, the full suite passes)
- [x] Live run with the new code shows the coverage table and no longer fires CRITICAL on DAI
- [x] `curl` confirms `DAIUSDT` returns 0 with HTTP 200 — fix would not work without the `price <= 0` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)