### PR TITLE
feat: add dashboard dark mode toggle

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -17,7 +17,7 @@ python3 -m http.server -d web 8080
 | Section | What it shows |
 |---|---|
 | **header** | Wordmark + per-source status chips (`binance` / `coinbase` / `coingecko`) showing freshness and any rate-limit backoff. |
-| **controls** | Coin list, warn/critical (bps), refresh interval (s), `live / 1d / 7d / 30d / 90d / 1y` mode, `individual / joint` view. |
+| **controls** | Coin list, warn/critical (bps), refresh interval (s), dark/light theme toggle, `live / 1d / 7d / 30d / 90d / 1y` mode, `individual / joint` view. |
 | **indicators** | Checkbox row of pre-built overlays (EWMA, Bollinger upper/lower, volatility, drawdown, cross-source divergence). Toggle anytime. |
 | **joint chart** *(joint view)* | Big multi-coin SVG time series. |
 | **coins** | Per-coin cards. In `individual` view each card has its own full chart with active indicators overlaid; in `joint` view the per-card chart hides and the joint chart takes the stage. |

--- a/web/index.html
+++ b/web/index.html
@@ -18,12 +18,15 @@
   a:hover { color: var(--mark); border-bottom-color: var(--mark); }
 
   /* Header */
-  header { position: sticky; top: 0; z-index: 10; display: flex; justify-content: space-between; align-items: center; padding: var(--s-3) var(--s-4); background: rgba(11, 11, 13, 0.85); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); font-size: var(--t-1); gap: var(--s-3); flex-wrap: wrap; }
+  header { position: sticky; top: 0; z-index: 10; display: flex; justify-content: space-between; align-items: center; padding: var(--s-3) var(--s-4); background: var(--header-bg); backdrop-filter: blur(8px); border-bottom: 1px solid var(--line); font-size: var(--t-1); gap: var(--s-3); flex-wrap: wrap; }
   header .wm { color: var(--fg); font-weight: 500; border-bottom: none; }
   header .wm em { color: var(--mark); font-style: normal; font-weight: 700; }
   header nav { display: flex; gap: var(--s-3); align-items: center; flex-wrap: wrap; }
   header nav a { color: var(--fg-faint); border-bottom: none; }
   header nav a:hover { color: var(--fg); border-bottom: none; }
+  .theme-toggle { white-space: nowrap; }
+  .theme-toggle::before { content: '☾'; }
+  body.theme-light .theme-toggle::before { content: '☀'; }
 
   /* Layout */
   main { max-width: var(--col); margin: 0 auto; padding: var(--s-5) var(--s-4) var(--s-6); }
@@ -168,6 +171,7 @@
     <span class="src-chip" data-src="coinbase"><span class="dot"></span><span class="name">coinbase</span><span class="age">—</span></span>
     <span class="src-chip" data-src="coingecko"><span class="dot"></span><span class="name">coingecko</span><span class="age">—</span></span>
     <span class="src-chip" data-src="jupiter"><span class="dot"></span><span class="name">jupiter</span><span class="age">—</span></span>
+    <button class="btn ghost theme-toggle" id="themeToggle" type="button" aria-pressed="false"> theme</button>
     <a href="https://github.com/kcolbchain/depeg-monitor/blob/main/docs/DEPEG_ORACLES.md">oracles</a>
     <a href="https://github.com/kcolbchain/depeg-monitor">source</a>
     <a href="https://github.com/kcolbchain/brand">brand</a>
@@ -1207,6 +1211,31 @@ function setView(next) {
   if (view === 'individual') drawAllCardCharts();
 }
 
+function preferredTheme() {
+  try {
+    const saved = localStorage.getItem('depegMonitor.theme');
+    if (saved === 'light' || saved === 'dark') return saved;
+  } catch {}
+  return window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+}
+function applyTheme(theme) {
+  const isLight = theme === 'light';
+  document.body.classList.toggle('theme-light', isLight);
+  const toggle = document.getElementById('themeToggle');
+  if (toggle) {
+    toggle.setAttribute('aria-pressed', String(isLight));
+    toggle.title = `Switch to ${isLight ? 'dark' : 'light'} mode`;
+    toggle.lastChild.textContent = isLight ? ' light' : ' dark';
+  }
+}
+function setTheme(theme) {
+  if (theme !== 'light' && theme !== 'dark') theme = 'dark';
+  applyTheme(theme);
+  try { localStorage.setItem('depegMonitor.theme', theme); } catch {}
+  if (view === 'joint') drawJointChart();
+  if (view === 'individual') drawAllCardCharts();
+}
+
 function applyCoins() {
   activeCoins = parseCoinsInput();
   document.getElementById('coinsMeta').textContent = `${activeCoins.length} tracked`;
@@ -1242,6 +1271,7 @@ function boot() {
     const saved = localStorage.getItem('depegMonitor.coinsInput');
     if (saved) document.getElementById('coinsInput').value = saved;
   } catch {}
+  applyTheme(preferredTheme());
   setView('individual');
   applyCoins();
   renderIndicatorList();
@@ -1257,6 +1287,9 @@ function boot() {
   document.querySelectorAll('#modeSeg button').forEach(b => b.addEventListener('click', () => setMode(b.dataset.mode)));
   document.querySelectorAll('#viewSeg button').forEach(b => b.addEventListener('click', () => setView(b.dataset.view)));
   document.querySelectorAll('#streamSeg button').forEach(b => b.addEventListener('click', () => setStream(b.dataset.stream)));
+  document.getElementById('themeToggle').addEventListener('click', () => {
+    setTheme(document.body.classList.contains('theme-light') ? 'dark' : 'light');
+  });
 
   document.getElementById('sandboxRun').addEventListener('click', compileSandbox);
   document.getElementById('sandboxClear').addEventListener('click', () => { sandboxFn = null; appendLog('ok', 'sandbox cleared'); if (view === 'individual') drawAllCardCharts(); });

--- a/web/tokens.css
+++ b/web/tokens.css
@@ -3,10 +3,12 @@
  * https://github.com/kcolbchain/brand/blob/main/tokens.css
  */
 :root {
+  color-scheme: dark;
   /* Surfaces — near-black, one elevation, hairline borders */
   --bg:        #0b0b0d;
   --bg-elev:   #131316;
   --line:      #1f1f24;
+  --header-bg: rgba(11, 11, 13, 0.85);
 
   /* Type — three weights of grey, nothing more */
   --fg:        #ededf0;
@@ -52,4 +54,26 @@
   --s-usdc: #6aa3e0;
   --s-usdt: #6ec07a;
   --s-dai:  var(--mark);
+}
+
+body.theme-light {
+  color-scheme: light;
+  --bg:        #f7f7f4;
+  --bg-elev:   #ffffff;
+  --line:      #dadad2;
+  --header-bg: rgba(247, 247, 244, 0.85);
+
+  --fg:        #19191d;
+  --fg-muted:  #55555d;
+  --fg-faint:  #797981;
+
+  --mark:      #7a6600;
+  --mark-soft: rgba(122, 102, 0, 0.12);
+
+  --ok:        #237a35;
+  --warn:      #8a6500;
+  --hot:       #ad3333;
+  --ok-soft:   rgba(35, 122, 53, 0.12);
+  --warn-soft: rgba(138, 101, 0, 0.12);
+  --hot-soft:  rgba(173, 51, 51, 0.12);
 }


### PR DESCRIPTION
## Summary
- Adds a vanilla JS dark/light theme toggle in the dashboard header
- Uses CSS custom properties for the light palette and header backdrop
- Persists the selected theme in `localStorage` and falls back to `prefers-color-scheme` on first visit
- Redraws SVG charts after theme changes so chart axes/thresholds use the active colors

## Verification
- `python3` assertions checked the theme toggle, `localStorage` key, `prefers-color-scheme` fallback, and `body.theme-light` CSS override
- Served `web/` with `python3 -m http.server` and fetched `/`, `/tokens.css`, and `/indicators.js` successfully
- Independent review found no blocking security concerns or logic errors

Closes #33
/claim #33
