### PR TITLE
Add fuzz harness for depeg tick and threshold invariants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = ["aiohttp>=3.9.0", "web3>=6.0.0", "pydantic>=2.0.0", "pyyaml>=6.0
 depeg-monitor = "depeg_monitor.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-asyncio>=0.21"]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "hypothesis>=6.100"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/depeg_monitor/config.py
+++ b/src/depeg_monitor/config.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+import math
 from typing import Optional
+
+from pydantic import BaseModel, field_validator, model_validator
 
 
 class StablecoinConfig(BaseModel):
@@ -11,6 +13,25 @@ class StablecoinConfig(BaseModel):
     peg: float = 1.0
     warn_threshold: float = 0.005
     critical_threshold: float = 0.01
+
+    @field_validator("peg", "warn_threshold", "critical_threshold")
+    @classmethod
+    def values_must_be_finite(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("threshold and peg values must be finite")
+        return value
+
+    @model_validator(mode="after")
+    def thresholds_must_be_ordered(self) -> "StablecoinConfig":
+        if self.peg <= 0:
+            raise ValueError("peg must be positive")
+        if self.warn_threshold < 0:
+            raise ValueError("warn_threshold must be non-negative")
+        if self.critical_threshold < 0:
+            raise ValueError("critical_threshold must be non-negative")
+        if self.critical_threshold < self.warn_threshold:
+            raise ValueError("critical_threshold must be greater than or equal to warn_threshold")
+        return self
 
 
 class DexSourceConfig(BaseModel):
@@ -42,3 +63,10 @@ class MonitorConfig(BaseModel):
     sources: SourcesConfig = SourcesConfig()
     alerts: AlertsConfig = AlertsConfig()
     interval_seconds: int = 30
+
+    @field_validator("interval_seconds")
+    @classmethod
+    def interval_must_be_positive(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("interval_seconds must be positive")
+        return value

--- a/src/depeg_monitor/fuzzing.py
+++ b/src/depeg_monitor/fuzzing.py
@@ -1,0 +1,115 @@
+"""Pure helpers used by the depeg-monitor fuzz harness.
+
+The monitor's live loop is async and network-backed. These helpers keep the
+price-tick, threshold, and aggregation invariants testable without touching
+external exchanges.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from .alerts.base import AlertLevel
+
+
+class TickParseError(ValueError):
+    """Raised when a raw price tick cannot be normalized safely."""
+
+
+@dataclass(frozen=True)
+class PriceTick:
+    symbol: str
+    price: float
+    timestamp: int
+    source: str = "unknown"
+
+
+def parse_price_tick(payload: bytes | str | Mapping[str, object]) -> PriceTick:
+    """Parse a raw tick payload into a finite positive price observation."""
+    if isinstance(payload, bytes):
+        try:
+            payload = payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise TickParseError("tick payload is not utf-8") from exc
+
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise TickParseError("tick payload is not valid json") from exc
+
+    if not isinstance(payload, Mapping):
+        raise TickParseError("tick payload must be an object")
+
+    symbol = str(payload.get("symbol", "")).strip().upper()
+    source = str(payload.get("source", "unknown")).strip() or "unknown"
+
+    try:
+        price = float(payload["price"])
+        timestamp = int(payload.get("timestamp", payload.get("ts", 0)))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise TickParseError("tick payload has invalid price or timestamp") from exc
+
+    if not symbol:
+        raise TickParseError("tick payload is missing symbol")
+    if not math.isfinite(price) or price <= 0:
+        raise TickParseError("tick price must be finite and positive")
+    if timestamp < 0:
+        raise TickParseError("tick timestamp must be non-negative")
+
+    return PriceTick(symbol=symbol, price=price, timestamp=timestamp, source=source)
+
+
+def validate_thresholds(peg: float, warn_threshold: float, critical_threshold: float) -> None:
+    values = (peg, warn_threshold, critical_threshold)
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("peg and thresholds must be finite")
+    if peg <= 0:
+        raise ValueError("peg must be positive")
+    if warn_threshold < 0 or critical_threshold < 0:
+        raise ValueError("thresholds must be non-negative")
+    if critical_threshold < warn_threshold:
+        raise ValueError("critical_threshold must be greater than or equal to warn_threshold")
+
+
+def classify_price(
+    price: float,
+    *,
+    peg: float,
+    warn_threshold: float,
+    critical_threshold: float,
+) -> AlertLevel | None:
+    """Return the alert level for a price or None when it is in range."""
+    validate_thresholds(peg, warn_threshold, critical_threshold)
+    if not math.isfinite(price) or price <= 0:
+        raise ValueError("price must be finite and positive")
+
+    deviation = abs(price - peg) / peg
+    if deviation >= critical_threshold:
+        return AlertLevel.CRITICAL
+    if deviation >= warn_threshold:
+        return AlertLevel.WARN
+    return None
+
+
+def median_price(readings: Mapping[str, float] | Iterable[tuple[str, float]]) -> float | None:
+    """Return the deterministic median of finite positive source readings."""
+    items = readings.items() if isinstance(readings, Mapping) else readings
+    clean = []
+
+    for source, value in items:
+        try:
+            price = float(value)
+        except (TypeError, ValueError):
+            continue
+        if str(source).strip() and math.isfinite(price) and price > 0:
+            clean.append(price)
+
+    if not clean:
+        return None
+
+    return float(statistics.median(sorted(clean)))

--- a/tests/test_fuzz_harness.py
+++ b/tests/test_fuzz_harness.py
@@ -1,0 +1,136 @@
+import json
+import math
+
+import pytest
+from hypothesis import given, settings, strategies as st
+from pydantic import ValidationError
+
+from depeg_monitor.alerts.base import AlertLevel
+from depeg_monitor.config import MonitorConfig, StablecoinConfig
+from depeg_monitor.fuzzing import (
+    TickParseError,
+    classify_price,
+    median_price,
+    parse_price_tick,
+    validate_thresholds,
+)
+
+
+finite_prices = st.floats(min_value=0.000001, max_value=10_000, allow_nan=False, allow_infinity=False)
+finite_thresholds = st.floats(min_value=0, max_value=10, allow_nan=False, allow_infinity=False)
+
+
+@given(st.binary(max_size=512))
+@settings(max_examples=150)
+def test_fuzz_price_tick_ingestion_never_panics(payload):
+    try:
+        tick = parse_price_tick(payload)
+    except TickParseError:
+        return
+
+    assert tick.symbol
+    assert math.isfinite(tick.price)
+    assert tick.price > 0
+    assert tick.timestamp >= 0
+
+
+@given(
+    symbol=st.text(min_size=1, max_size=12),
+    source=st.text(max_size=24),
+    price=finite_prices,
+    timestamp=st.integers(min_value=0, max_value=2**63 - 1),
+)
+@settings(max_examples=150)
+def test_fuzz_valid_json_ticks_round_trip(symbol, source, price, timestamp):
+    payload = json.dumps(
+        {
+            "symbol": symbol,
+            "source": source,
+            "price": price,
+            "timestamp": timestamp,
+        }
+    )
+
+    tick = parse_price_tick(payload)
+
+    assert tick.symbol == symbol.strip().upper()
+    assert tick.source == (source.strip() or "unknown")
+    assert tick.price == price
+    assert tick.timestamp == timestamp
+
+
+@given(
+    price=finite_prices,
+    peg=finite_prices,
+    warn=finite_thresholds,
+    critical=finite_thresholds,
+)
+@settings(max_examples=200)
+def test_fuzz_threshold_classifier_matches_monitor_semantics(price, peg, warn, critical):
+    if critical < warn:
+        with pytest.raises(ValueError):
+            validate_thresholds(peg, warn, critical)
+        return
+
+    level = classify_price(
+        price,
+        peg=peg,
+        warn_threshold=warn,
+        critical_threshold=critical,
+    )
+    deviation = abs(price - peg) / peg
+
+    if deviation >= critical:
+        assert level == AlertLevel.CRITICAL
+    elif deviation >= warn:
+        assert level == AlertLevel.WARN
+    else:
+        assert level is None
+
+
+@given(
+    peg=finite_prices,
+    warn=st.floats(min_value=0.000001, max_value=0.25, allow_nan=False, allow_infinity=False),
+    offsets=st.lists(st.floats(min_value=-0.99, max_value=0.99, allow_nan=False, allow_infinity=False), min_size=1),
+)
+@settings(max_examples=150)
+def test_fuzz_in_range_state_sequence_never_alerts(peg, warn, offsets):
+    critical = warn * 2
+
+    for offset in offsets:
+        bounded = max(min(offset, warn * 0.99), -warn * 0.99)
+        price = peg * (1 + bounded)
+        assert classify_price(price, peg=peg, warn_threshold=warn, critical_threshold=critical) is None
+
+
+@given(
+    readings=st.dictionaries(
+        keys=st.text(min_size=1, max_size=12),
+        values=finite_prices,
+        min_size=1,
+        max_size=9,
+    )
+)
+@settings(max_examples=150)
+def test_fuzz_multi_source_median_is_order_independent(readings):
+    ordered = list(readings.items())
+    reversed_order = list(reversed(ordered))
+
+    assert median_price(ordered) == median_price(reversed_order)
+    assert median_price(readings) == median_price(ordered)
+
+
+@given(
+    peg=st.one_of(st.just(0.0), st.just(-1.0), st.just(float("nan")), st.just(float("inf"))),
+    warn=finite_thresholds,
+    critical=finite_thresholds,
+)
+def test_fuzz_malformed_config_rejects_bad_peg(peg, warn, critical):
+    with pytest.raises((ValidationError, ValueError)):
+        StablecoinConfig(symbol="USDC", peg=peg, warn_threshold=warn, critical_threshold=critical)
+
+
+@given(interval=st.integers(max_value=0))
+def test_fuzz_malformed_config_rejects_bad_interval(interval):
+    with pytest.raises(ValidationError):
+        MonitorConfig(interval_seconds=interval)


### PR DESCRIPTION
## Summary
- Add a pure Python fuzz harness for depeg-monitor tick parsing, threshold classification, and multi-source median aggregation.
- Add Hypothesis coverage for random byte tick ingestion, valid JSON tick round-trips, malformed threshold configs, in-range state sequences, and deterministic multi-source aggregation.
- Harden config validation so malformed pegs, thresholds, and monitor intervals are rejected before a live monitor starts.

## Validation
- `python -m py_compile src/depeg_monitor/config.py src/depeg_monitor/fuzzing.py tests/test_fuzz_harness.py`
- `python -m pytest tests/test_fuzz_harness.py -q` (7 passed)
- `python -m pytest tests/test_integration.py tests/test_cex_source.py -q` (22 passed)
- `python -m pytest -q` (63 passed, 1 external dependency deprecation warning)
- `git diff --check`

## CI note
I prepared a short fuzz-gate workflow step, but this OAuth token does not have GitHub `workflow` scope, so GitHub rejected pushing `.github/workflows/*`. The runnable gate is:

```bash
timeout 5s python -m pytest tests/test_fuzz_harness.py -q
```

Closes #32

/claim #32