### PR TITLE
Add depeg oracle aggregator

### DIFF
--- a/docs/DEPEG_ORACLES.md
+++ b/docs/DEPEG_ORACLES.md
@@ -6,8 +6,9 @@ signal — an alternative to closed, paywalled stablecoin-risk dashboards.
 
 > Status: draft 0.1. The wire format below is implemented by the
 > `depeg-monitor` Python library and the in-browser dashboard ships an
-> observer mode. The aggregation layer (multi-observer consensus, on-chain
-> attestation) is sketched here but not yet implemented.
+> observer mode. The aggregation layer now has a reference CLI for
+> multi-observer consensus; on-chain attestation remains sketched here but
+> not yet implemented.
 
 ## Why
 
@@ -115,6 +116,36 @@ GIVEN observations O_1 .. O_N for the same (coin, peg) within a 60s window:
 The aggregator's output is itself a verifiable artifact: anyone with the N
 raw observations can recompute the quorum view exactly.
 
+The reference CLI accepts a YAML feed allowlist or repeated `--feed` entries,
+tails each JSONL source once, verifies Ed25519 signatures, drops observations
+whose claimed median diverges from the recomputed source median by more than
+5 bps, and writes both consensus JSONL and a sidecar manifest of input hashes:
+
+```bash
+depeg-monitor aggregator run --feeds config/observers.yaml \
+    --window-seconds 60 --quorum-ratio 0.66 \
+    --out ./consensus.jsonl
+```
+
+Example feed config:
+
+```yaml
+observers:
+  - observer_id: did:web:example.com:obs-01
+    observer_pubkey: ed25519:ab12...
+    source: ./observations/obs-01.jsonl
+```
+
+You can also pass feeds directly:
+
+```bash
+depeg-monitor aggregator run \
+    --feed did:web:example.com:obs-01,ed25519:ab12...,./obs-01.jsonl \
+    --feed did:web:example.com:obs-02,ed25519:cd34...,./obs-02.jsonl \
+    --feed did:web:example.com:obs-03,ed25519:ef56...,./obs-03.jsonl \
+    --out ./consensus.jsonl
+```
+
 ## Trust model
 
 | Property | Guarantee |
@@ -214,7 +245,7 @@ layer and let real usage shape the answers.
 | JSONL file output | not yet implemented |
 | IPFS/IPNS publish | not yet implemented |
 | On-chain anchoring | not yet implemented |
-| Aggregator reference implementation | not yet implemented |
+| Aggregator reference implementation | available via `depeg-monitor aggregator run` |
 
 If you want to claim any of the above, [open an
 issue](https://github.com/kcolbchain/depeg-monitor/issues/new) and stake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "depeg-monitor"
 version = "0.1.0"
-dependencies = ["aiohttp>=3.9.0", "web3>=6.0.0", "pydantic>=2.0.0", "pyyaml>=6.0.0"]
+dependencies = ["aiohttp>=3.9.0", "web3>=6.0.0", "pydantic>=2.0.0", "pyyaml>=6.0.0", "pynacl>=1.5.0"]
 
 [project.scripts]
 depeg-monitor = "depeg_monitor.cli:main"

--- a/src/depeg_monitor/aggregator.py
+++ b/src/depeg_monitor/aggregator.py
@@ -1,0 +1,389 @@
+"""Reference aggregator for depeg oracle observation feeds."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import math
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+try:
+    from nacl.exceptions import BadSignatureError
+    from nacl.signing import VerifyKey
+except ImportError:  # pragma: no cover - dependency is declared in pyproject
+    BadSignatureError = Exception
+    VerifyKey = None
+
+
+OBSERVATION_SCHEMA = "depeg-oracle/observation/v1"
+CONSENSUS_SCHEMA = "depeg-oracle/consensus/v1"
+RECOMPUTE_TOLERANCE_BPS = 5.0
+
+
+@dataclass(frozen=True)
+class ObserverFeed:
+    observer_id: str
+    observer_pubkey: str
+    source: str
+
+
+@dataclass(frozen=True)
+class CandidateObservation:
+    feed: ObserverFeed
+    observation: dict[str, Any]
+    observation_hash: str
+    ts_epoch: float
+    window_start: int
+    coin: str
+    peg: float
+
+
+def canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def unsigned_payload(observation: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(observation)
+    payload.pop("sig", None)
+    payload.pop("signature", None)
+    return payload
+
+
+def observation_hash(observation: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(observation)).hexdigest()
+
+
+def _decode_key_material(value: str, prefix: str | None = None) -> bytes:
+    if prefix and value.startswith(f"{prefix}:"):
+        value = value.split(":", 1)[1]
+    value = value.strip()
+    if not value:
+        raise ValueError("empty key material")
+    try:
+        return bytes.fromhex(value)
+    except ValueError:
+        return base64.b64decode(value, validate=True)
+
+
+def _decode_signature(value: str) -> bytes:
+    return _decode_key_material(value, "ed25519")
+
+
+def _decode_pubkey(value: str) -> bytes:
+    return _decode_key_material(value, "ed25519")
+
+
+def verify_observation_signature(observation: dict[str, Any], observer_pubkey: str) -> bool:
+    """Verify the observation signature against the configured Ed25519 pubkey."""
+    if VerifyKey is None:
+        return False
+    signature = observation.get("sig") or observation.get("signature")
+    if not isinstance(signature, str):
+        return False
+
+    try:
+        configured_key = _decode_pubkey(observer_pubkey)
+        observed_pubkey = observation.get("observer_pubkey")
+        if isinstance(observed_pubkey, str) and _decode_pubkey(observed_pubkey) != configured_key:
+            return False
+        VerifyKey(configured_key).verify(canonical_json_bytes(unsigned_payload(observation)), _decode_signature(signature))
+        return True
+    except (BadSignatureError, ValueError, binascii.Error):
+        return False
+
+
+def parse_ts(value: Any) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str):
+        raise ValueError("timestamp must be ISO-8601 string or epoch seconds")
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized).timestamp()
+
+
+def iso_utc(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def median(values: Iterable[float]) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        raise ValueError("median requires at least one value")
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+def bps_delta(price: float, peg: float) -> float:
+    if peg <= 0 or not math.isfinite(peg):
+        raise ValueError("peg must be positive and finite")
+    return ((price - peg) / peg) * 10_000
+
+
+def severity_from_bps(abs_bps: float, warn_bps: float = 50.0, critical_bps: float = 100.0) -> str:
+    if abs_bps >= critical_bps:
+        return "critical"
+    if abs_bps >= warn_bps:
+        return "warn"
+    return "normal"
+
+
+def recompute_median_price(observation: dict[str, Any]) -> float:
+    sources = observation.get("sources")
+    if not isinstance(sources, list) or not sources:
+        raise ValueError("observation must include non-empty sources")
+    prices: list[float] = []
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        price = source.get("price")
+        if isinstance(price, (int, float)) and math.isfinite(float(price)):
+            prices.append(float(price))
+    if not prices:
+        raise ValueError("sources must include at least one finite price")
+    return median(prices)
+
+
+def claimed_price_matches_sources(observation: dict[str, Any], tolerance_bps: float = RECOMPUTE_TOLERANCE_BPS) -> bool:
+    try:
+        claimed = float(observation["median_price"])
+        peg = float(observation["peg"])
+        recomputed = recompute_median_price(observation)
+        return abs(claimed - recomputed) / peg * 10_000 <= tolerance_bps
+    except (KeyError, TypeError, ValueError):
+        return False
+
+
+def load_observer_feeds(feeds_path: str | Path | None, feed_args: list[str] | None = None) -> list[ObserverFeed]:
+    raw_feeds: list[dict[str, Any]] = []
+
+    if feeds_path:
+        with open(feeds_path, encoding="utf-8") as f:
+            loaded = yaml.safe_load(f) or []
+        if isinstance(loaded, dict):
+            loaded = loaded.get("observers") or loaded.get("feeds") or []
+        if not isinstance(loaded, list):
+            raise ValueError("feeds YAML must be a list or contain observers:/feeds:")
+        raw_feeds.extend(loaded)
+
+    for feed_arg in feed_args or []:
+        pieces = feed_arg.split(",", 2)
+        if len(pieces) != 3:
+            raise ValueError("--feed must be observer_id,observer_pubkey,source")
+        raw_feeds.append({"observer_id": pieces[0], "observer_pubkey": pieces[1], "source": pieces[2]})
+
+    feeds = [
+        ObserverFeed(
+            observer_id=str(raw["observer_id"]),
+            observer_pubkey=str(raw["observer_pubkey"]),
+            source=str(raw["source"]),
+        )
+        for raw in raw_feeds
+    ]
+    if not feeds:
+        raise ValueError("at least one observer feed is required")
+    return feeds
+
+
+def load_jsonl_source(source: str) -> list[dict[str, Any]]:
+    if source.startswith(("http://", "https://")):
+        with urllib.request.urlopen(source, timeout=10) as response:
+            lines = response.read().decode("utf-8").splitlines()
+    else:
+        lines = Path(source).read_text(encoding="utf-8").splitlines()
+    observations: list[dict[str, Any]] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        loaded = json.loads(line)
+        if isinstance(loaded, dict):
+            observations.append(loaded)
+    return observations
+
+
+def _candidate_from_observation(feed: ObserverFeed, observation: dict[str, Any], window_seconds: int) -> CandidateObservation | None:
+    try:
+        if observation.get("schema", OBSERVATION_SCHEMA) != OBSERVATION_SCHEMA:
+            return None
+        if observation.get("observer_id") != feed.observer_id:
+            return None
+        ts_epoch = parse_ts(observation["ts"])
+        peg = float(observation["peg"])
+        coin = str(observation["coin"])
+        window_start = int(ts_epoch // window_seconds) * window_seconds
+        return CandidateObservation(feed, observation, observation_hash(observation), ts_epoch, window_start, coin, peg)
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def collect_candidates(feeds: list[ObserverFeed], window_seconds: int) -> list[CandidateObservation]:
+    candidates: list[CandidateObservation] = []
+    for feed in feeds:
+        for observation in load_jsonl_source(feed.source):
+            candidate = _candidate_from_observation(feed, observation, window_seconds)
+            if candidate is not None:
+                candidates.append(candidate)
+    return candidates
+
+
+def _latest_per_observer(candidates: list[CandidateObservation]) -> list[CandidateObservation]:
+    latest: dict[str, CandidateObservation] = {}
+    for candidate in candidates:
+        previous = latest.get(candidate.feed.observer_id)
+        if previous is None or candidate.ts_epoch > previous.ts_epoch:
+            latest[candidate.feed.observer_id] = candidate
+    return list(latest.values())
+
+
+def _observation_ref(candidate: CandidateObservation) -> dict[str, str]:
+    observation_id = candidate.observation.get("observation_id") or candidate.observation.get("id")
+    if observation_id is None:
+        observation_id = candidate.observation_hash[:16]
+    return {
+        "observer_id": candidate.feed.observer_id,
+        "observation_id": str(observation_id),
+        "hash": candidate.observation_hash,
+    }
+
+
+def _drop_ref(candidate: CandidateObservation, reason: str) -> dict[str, str]:
+    ref = _observation_ref(candidate)
+    ref["reason"] = reason
+    return ref
+
+
+def _validation_status(candidate: CandidateObservation) -> str | None:
+    if not verify_observation_signature(candidate.observation, candidate.feed.observer_pubkey):
+        return "invalid signature"
+    if not claimed_price_matches_sources(candidate.observation):
+        return "median recompute mismatch"
+    return None
+
+
+def aggregate_observations(
+    feeds: list[ObserverFeed],
+    window_seconds: int = 60,
+    quorum_ratio: float = 2 / 3,
+) -> list[dict[str, Any]]:
+    if window_seconds <= 0:
+        raise ValueError("window_seconds must be positive")
+    if quorum_ratio <= 0 or quorum_ratio > 1:
+        raise ValueError("quorum_ratio must be within (0, 1]")
+
+    quorum = max(3, math.ceil(quorum_ratio * len(feeds)))
+    groups: dict[tuple[str, float, int], list[CandidateObservation]] = {}
+    for candidate in collect_candidates(feeds, window_seconds):
+        groups.setdefault((candidate.coin, candidate.peg, candidate.window_start), []).append(candidate)
+
+    records: list[dict[str, Any]] = []
+    for (coin, peg, window_start), candidates in sorted(groups.items(), key=lambda item: item[0]):
+        dropped: list[dict[str, str]] = []
+        valid: list[CandidateObservation] = []
+        for candidate in _latest_per_observer(candidates):
+            reason = _validation_status(candidate)
+            if reason:
+                dropped.append(_drop_ref(candidate, reason))
+            else:
+                valid.append(candidate)
+
+        base_record: dict[str, Any] = {
+            "schema": CONSENSUS_SCHEMA,
+            "ts": iso_utc(max((candidate.ts_epoch for candidate in candidates), default=window_start)),
+            "window_start": iso_utc(window_start),
+            "window_seconds": window_seconds,
+            "coin": coin,
+            "peg": peg,
+            "declared_observers": len(feeds),
+            "quorum": quorum,
+            "valid_observers": len(valid),
+            "observations": [_observation_ref(candidate) for candidate in valid],
+            "dropped_observations": dropped,
+        }
+
+        if len(valid) < quorum:
+            base_record.update({"status": "indeterminate", "reason": "insufficient observers"})
+            records.append(base_record)
+            continue
+
+        consensus_price = median(float(candidate.observation["median_price"]) for candidate in valid)
+        consensus_bps = bps_delta(consensus_price, peg)
+        config = valid[0].observation.get("config") if valid else {}
+        warn_bps = float(config.get("warn_threshold_bps", 50.0)) if isinstance(config, dict) else 50.0
+        critical_bps = float(config.get("critical_threshold_bps", 100.0)) if isinstance(config, dict) else 100.0
+        base_record.update(
+            {
+                "status": "consensus",
+                "consensus_price": consensus_price,
+                "consensus_bps": consensus_bps,
+                "severity": severity_from_bps(abs(consensus_bps), warn_bps, critical_bps),
+            }
+        )
+        records.append(base_record)
+
+    return records
+
+
+def write_consensus(records: list[dict[str, Any]], out_path: str | Path, manifest_path: str | Path | None = None) -> Path:
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+
+    manifest = Path(manifest_path) if manifest_path else out.with_suffix(out.suffix + ".manifest.json")
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest_records = [
+        {
+            "record_hash": observation_hash(record),
+            "coin": record["coin"],
+            "peg": record["peg"],
+            "window_start": record["window_start"],
+            "status": record["status"],
+            "input_observation_hashes": [item["hash"] for item in record["observations"]],
+        }
+        for record in records
+    ]
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema": "depeg-oracle/consensus-manifest/v1",
+                "record_count": len(records),
+                "records": manifest_records,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="depeg-monitor aggregator run")
+    parser.add_argument("--feeds", help="YAML file containing observer feeds")
+    parser.add_argument("--feed", action="append", default=[], help="observer_id,observer_pubkey,source")
+    parser.add_argument("--window-seconds", type=int, default=60)
+    parser.add_argument("--quorum-ratio", type=float, default=2 / 3)
+    parser.add_argument("--out", required=True, help="Consensus JSONL output path")
+    parser.add_argument("--manifest-out", help="Sidecar manifest output path")
+    return parser
+
+
+def run_aggregator_cli(argv: list[str]) -> int:
+    args = build_parser().parse_args(argv)
+    feeds = load_observer_feeds(args.feeds, args.feed)
+    records = aggregate_observations(feeds, args.window_seconds, args.quorum_ratio)
+    write_consensus(records, args.out, args.manifest_out)
+    return 0

--- a/src/depeg_monitor/cli.py
+++ b/src/depeg_monitor/cli.py
@@ -113,6 +113,10 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] == "history":
         cmd_history(sys.argv[2:])
         return
+    if len(sys.argv) > 2 and sys.argv[1:3] == ["aggregator", "run"]:
+        from .aggregator import run_aggregator_cli
+        run_aggregator_cli(sys.argv[3:])
+        return
 
     config_path = "config/default.yaml"
     for i, arg in enumerate(sys.argv):

--- a/src/depeg_monitor/observer.py
+++ b/src/depeg_monitor/observer.py
@@ -72,8 +72,7 @@ def run_observer_loop(observe_fn, output: str = "stdout", interval: int = 60):
             print(line, file=sys.stderr, flush=True)
         else:
             with open(output, "a") as f:
-                f.write(line + "
-")
+                f.write(line + "\n")
         time.sleep(interval)
 
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,182 @@
+import json
+from pathlib import Path
+
+import yaml
+from nacl.signing import SigningKey
+
+from depeg_monitor.aggregator import (
+    aggregate_observations,
+    load_observer_feeds,
+    observation_hash,
+    run_aggregator_cli,
+)
+
+
+def _signed_observation(
+    key: SigningKey,
+    observer_id: str,
+    ts: str,
+    median_price: float,
+    source_prices: list[float],
+) -> dict:
+    observation = {
+        "schema": "depeg-oracle/observation/v1",
+        "observer_id": observer_id,
+        "observer_pubkey": f"ed25519:{bytes(key.verify_key).hex()}",
+        "ts": ts,
+        "coin": "USDC",
+        "peg": 1.0,
+        "median_price": median_price,
+        "deviation_bps": (median_price - 1.0) * 10_000,
+        "severity": "normal",
+        "sources": [
+            {"name": f"source-{index}", "pair": "USDC-USD", "price": price, "ts": ts}
+            for index, price in enumerate(source_prices)
+        ],
+        "config": {
+            "warn_threshold_bps": 50,
+            "critical_threshold_bps": 100,
+            "aggregator": "median",
+        },
+    }
+    payload = json.dumps(observation, sort_keys=True, separators=(",", ":")).encode()
+    observation["sig"] = f"ed25519:{key.sign(payload).signature.hex()}"
+    return observation
+
+
+def _write_feed(path: Path, observations: list[dict]) -> None:
+    path.write_text(
+        "".join(json.dumps(observation, sort_keys=True, separators=(",", ":")) + "\n" for observation in observations),
+        encoding="utf-8",
+    )
+
+
+def _feeds_config(tmp_path: Path, feed_count: int = 3) -> tuple[Path, list[SigningKey]]:
+    keys = [SigningKey.generate() for _ in range(feed_count)]
+    feeds = []
+    for index, key in enumerate(keys):
+        source = tmp_path / f"observer-{index}.jsonl"
+        feeds.append(
+            {
+                "observer_id": f"observer-{index}",
+                "observer_pubkey": f"ed25519:{bytes(key.verify_key).hex()}",
+                "source": str(source),
+            }
+        )
+    config = tmp_path / "observers.yaml"
+    config.write_text(yaml.safe_dump({"observers": feeds}), encoding="utf-8")
+    return config, keys
+
+
+def test_aggregator_round_trips_verifiable_observations(tmp_path):
+    feeds_path, keys = _feeds_config(tmp_path, 3)
+    observations = [
+        _signed_observation(keys[0], "observer-0", "2026-05-24T14:21:03Z", 0.9940, [0.9939, 0.9940, 0.9941]),
+        _signed_observation(keys[1], "observer-1", "2026-05-24T14:21:05Z", 0.9942, [0.9941, 0.9942, 0.9943]),
+        _signed_observation(keys[2], "observer-2", "2026-05-24T14:21:06Z", 0.9944, [0.9943, 0.9944, 0.9945]),
+    ]
+    for index, observation in enumerate(observations):
+        _write_feed(tmp_path / f"observer-{index}.jsonl", [observation])
+
+    records = aggregate_observations(load_observer_feeds(feeds_path), window_seconds=60)
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["status"] == "consensus"
+    assert record["consensus_price"] == 0.9942
+    assert record["valid_observers"] == 3
+    assert [item["hash"] for item in record["observations"]] == [observation_hash(item) for item in observations]
+
+
+def test_aggregator_drops_lying_observer_and_keeps_quorum(tmp_path):
+    feeds_path, keys = _feeds_config(tmp_path, 4)
+    honest = [
+        _signed_observation(keys[0], "observer-0", "2026-05-24T14:21:03Z", 0.9940, [0.9939, 0.9940, 0.9941]),
+        _signed_observation(keys[1], "observer-1", "2026-05-24T14:21:04Z", 0.9942, [0.9941, 0.9942, 0.9943]),
+        _signed_observation(keys[2], "observer-2", "2026-05-24T14:21:05Z", 0.9944, [0.9943, 0.9944, 0.9945]),
+    ]
+    liar = _signed_observation(keys[3], "observer-3", "2026-05-24T14:21:06Z", 0.9995, [0.9942, 0.9943, 0.9944])
+    for index, observation in enumerate([*honest, liar]):
+        _write_feed(tmp_path / f"observer-{index}.jsonl", [observation])
+
+    record = aggregate_observations(load_observer_feeds(feeds_path), window_seconds=60)[0]
+
+    assert record["status"] == "consensus"
+    assert record["valid_observers"] == 3
+    assert record["consensus_price"] == 0.9942
+    assert record["dropped_observations"] == [
+        {
+            "observer_id": "observer-3",
+            "observation_id": observation_hash(liar)[:16],
+            "hash": observation_hash(liar),
+            "reason": "median recompute mismatch",
+        }
+    ]
+
+
+def test_aggregator_drops_invalid_signature(tmp_path):
+    feeds_path, keys = _feeds_config(tmp_path, 4)
+    valid_observations = [
+        _signed_observation(keys[0], "observer-0", "2026-05-24T14:21:03Z", 0.9940, [0.9939, 0.9940, 0.9941]),
+        _signed_observation(keys[1], "observer-1", "2026-05-24T14:21:04Z", 0.9942, [0.9941, 0.9942, 0.9943]),
+        _signed_observation(keys[2], "observer-2", "2026-05-24T14:21:05Z", 0.9944, [0.9943, 0.9944, 0.9945]),
+    ]
+    bad_sig = _signed_observation(keys[3], "observer-3", "2026-05-24T14:21:06Z", 0.9942, [0.9941, 0.9942, 0.9943])
+    bad_sig["sig"] = "ed25519:" + "00" * 64
+    for index, observation in enumerate([*valid_observations, bad_sig]):
+        _write_feed(tmp_path / f"observer-{index}.jsonl", [observation])
+
+    record = aggregate_observations(load_observer_feeds(feeds_path), window_seconds=60)[0]
+
+    assert record["status"] == "consensus"
+    assert record["valid_observers"] == 3
+    assert record["dropped_observations"][0]["observer_id"] == "observer-3"
+    assert record["dropped_observations"][0]["reason"] == "invalid signature"
+
+
+def test_aggregator_handles_missing_observers_as_indeterminate(tmp_path):
+    feeds_path, keys = _feeds_config(tmp_path, 4)
+    for index in range(2):
+        observation = _signed_observation(
+            keys[index],
+            f"observer-{index}",
+            "2026-05-24T14:21:03Z",
+            0.9940 + index * 0.0002,
+            [0.9939 + index * 0.0002, 0.9940 + index * 0.0002, 0.9941 + index * 0.0002],
+        )
+        _write_feed(tmp_path / f"observer-{index}.jsonl", [observation])
+    for index in (2, 3):
+        _write_feed(tmp_path / f"observer-{index}.jsonl", [])
+
+    record = aggregate_observations(load_observer_feeds(feeds_path), window_seconds=60)[0]
+
+    assert record["status"] == "indeterminate"
+    assert record["reason"] == "insufficient observers"
+    assert record["valid_observers"] == 2
+    assert record["quorum"] == 3
+
+
+def test_aggregator_cli_writes_jsonl_and_manifest(tmp_path):
+    feeds_path, keys = _feeds_config(tmp_path, 3)
+    for index, key in enumerate(keys):
+        observation = _signed_observation(
+            key,
+            f"observer-{index}",
+            "2026-05-24T14:21:03Z",
+            0.9940 + index * 0.0001,
+            [0.9939 + index * 0.0001, 0.9940 + index * 0.0001, 0.9941 + index * 0.0001],
+        )
+        _write_feed(tmp_path / f"observer-{index}.jsonl", [observation])
+
+    out = tmp_path / "consensus.jsonl"
+    manifest = tmp_path / "manifest.json"
+
+    assert run_aggregator_cli(["--feeds", str(feeds_path), "--out", str(out), "--manifest-out", str(manifest)]) == 0
+    record = json.loads(out.read_text(encoding="utf-8").strip())
+    manifest_payload = json.loads(manifest.read_text(encoding="utf-8"))
+
+    assert record["status"] == "consensus"
+    assert manifest_payload["record_count"] == 1
+    assert manifest_payload["records"][0]["input_observation_hashes"] == [
+        item["hash"] for item in record["observations"]
+    ]


### PR DESCRIPTION
/claim #21

## Summary
- add `depeg-monitor aggregator run` for YAML or CLI-provided observer feeds
- verify Ed25519-signed observations, drop invalid signatures, and drop observations whose claimed median differs from recomputed source median by more than 5 bps
- emit consensus JSONL records with quorum metadata plus a sidecar manifest of input observation hashes
- document the aggregator CLI and update the oracle status table
- fix observer JSONL newline output so the existing observer module parses cleanly

## Validation
- `python -m pytest tests\\test_aggregator.py -q`
- `python -m pytest -q`
- `python -m py_compile src\\depeg_monitor\\aggregator.py src\\depeg_monitor\\cli.py src\\depeg_monitor\\observer.py tests\\test_aggregator.py`
- `python -m depeg_monitor.cli aggregator run --help`
- `git diff --check`