### PR TITLE
fix(fuzz): tighten symbol strategy + add CI + drop orphan stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  pytest:
+    name: pytest (py${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+
+      - name: Install package + dev deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[dev]'
+
+      - name: Collect tests
+        run: pytest tests/ --collect-only -q
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # depeg-monitor
 
+[![CI](https://github.com/kcolbchain/depeg-monitor/actions/workflows/ci.yml/badge.svg)](https://github.com/kcolbchain/depeg-monitor/actions/workflows/ci.yml)
+
 Real-time stablecoin depeg detection and alerting. By [kcolbchain](https://kcolbchain.com) (est. 2015).
 
 ## Why this exists

--- a/tests/test_fuzz_harness.py
+++ b/tests/test_fuzz_harness.py
@@ -35,7 +35,7 @@ def test_fuzz_price_tick_ingestion_never_panics(payload):
 
 
 @given(
-    symbol=st.text(min_size=1, max_size=12),
+    symbol=st.text(min_size=1, max_size=12).filter(lambda s: s.strip() != ""),
     source=st.text(max_size=24),
     price=finite_prices,
     timestamp=st.integers(min_value=0, max_value=2**63 - 1),


### PR DESCRIPTION
## Summary

\`test_fuzz_valid_json_ticks_round_trip\` failed on main with the falsifying example:

\`\`\`
TickParseError: tick payload is missing symbol
Falsifying example: test_fuzz_valid_json_ticks_round_trip(
    symbol='\\x85',
    source='',
    price=1.0,
    timestamp=0,
)
\`\`\`

## Root cause

Hypothesis generated \`symbol='\\x85'\` (U+0085, Unicode NEL — classified as whitespace by Python's \`str.strip\`). The parser does:

\`\`\`python
symbol = str(payload.get(\"symbol\", \"\")).strip().upper()
...
if not symbol:
    raise TickParseError(\"tick payload is missing symbol\")
\`\`\`

So \`'\\x85'.strip()\` → \`''\` → rejected. **The parser is correct** — an empty asset symbol is nonsense. The test's strategy just didn't account for it: it generated symbols, the parser normalized to empty, the round-trip assertion failed.

## Fix

Tighten the Hypothesis strategy so the round-trip property only sees symbols that survive the parser's contract:

\`\`\`diff
-    symbol=st.text(min_size=1, max_size=12),
+    symbol=st.text(min_size=1, max_size=12).filter(lambda s: s.strip() != \"\"),
\`\`\`

After: **68 passed, 0 failed.** (was 67 passed, 1 failed)

## Drive-by

- CI workflow (pytest, py 3.11/3.12) + badge — the repo shipped tests but no automation.
- Deleted \`l1_add_dark_mode_toggle_to_the_moni.py\` — 0-byte orphan at repo root, matches the contrib-bot's \`l<level>_<truncated>.md/.py\` placeholder pattern. (Two more found and deleted in stylus-profiler and tt-crypto-primitives in separate PRs — there appears to be a bot-side leak.)